### PR TITLE
Adding compatibility for Julia 0.4

### DIFF
--- a/src/Sam.jl
+++ b/src/Sam.jl
@@ -108,7 +108,7 @@ end
 function parse_headerlines{S <: AbstractString}(headerlines::Vector{S})
     header = SamHeaderData()
     for line in headerlines
-        push!(header, parse_header_line(line))
+        push!(header, parse_headerline(line))
     end
     header
 end

--- a/src/Sam.jl
+++ b/src/Sam.jl
@@ -251,9 +251,7 @@ function read_bam_header(io::IO)
     headerlines = AbstractString[]
     headers = bytestring(tmp_header)
     push!(headerlines, rstrip(headers))
-    for line in headerlines
-      parse_headerlines(line)
-    end
+    parse_headerlines(headerlines)
 end
 
 function write_bam_header(io::IO, header::SamHeaderData)

--- a/src/Sam.jl
+++ b/src/Sam.jl
@@ -88,7 +88,7 @@ const SAM_MAGIC = "@HD\t"
 function parse_headerline(line::AbstractString)
     linetag = line[2:3]
     tagdict = OrderedDict{AbstractString, AbstractString}()
-    for kv in split(str, "\t")
+    for kv in split(line, "\t")
         k = kv[1:2]
         v = kv[4:end]
         tagdict[k] = v

--- a/src/Sam.jl
+++ b/src/Sam.jl
@@ -334,9 +334,9 @@ function read_alignment(b::BamFile)
     info = unpack(b.io, AlignmentInfo, strpack_asize, align_packed, :LittleEndian)
 
     readname = replace(bytestring(read(b.io, Array(UInt8, info.l_readname))), r"\0", "")
-    cigar = read(b.io, Array(UInt32, info.n_cigar_op))
-    seq = read(b.io, Array(UInt8, (info.rlen+1)>>1))
-    qual = read(b.io, Array(UInt8, info.rlen))
+    enc_c = read(b.io, Array(UInt32, info.n_cigar_op))
+    enc_s = read(b.io, Array(UInt8, (info.rlen+1)>>1))
+    enc_q = read(b.io, Array(UInt8, info.rlen))
 
     bytesread = ainfo_size +
                 info.l_readname +
@@ -345,8 +345,23 @@ function read_alignment(b::BamFile)
                 info.rlen
     # TODO: parse
     aux = read(b.io, Array(UInt8, blocksize-bytesread))
+    cigar = parseCigar(enc_c)
+    seq = parseSeq(enc_s)
+    qual = parseQual(enc_q)
 
     BamAlignment(info, readname, cigar, seq, qual, aux)
+end
+
+function parseCigar(c::Array{UInt32})
+  return c
+end
+
+function parseSeq(s::Array{UInt8})
+  return s
+end
+
+function parseQual(q::Array{UInt8})
+  return q
 end
 
 function write_alignment(b::BamFile, r::BamAlignment)

--- a/src/Sam.jl
+++ b/src/Sam.jl
@@ -65,7 +65,7 @@ end
 
 function push!(sm::SamHeaderData, kv::Tuple{AbstractString, Any})
     (tag, value) = kv
-    if has(sm, tag)
+    if tag in keys(sm)
         push!(sm[tag], value)
     else
         sm[tag] = [value]
@@ -379,7 +379,7 @@ function read_meta(io::IO; ftype="bam")
         refs = read_bam_refs(io)
 
         # Make sure refs match
-        if has(header, "SQ")
+        if "SQ" in keys(header)
             header_refs = get_header_refs(header)
             if length(header_refs) != length(refs)
                 error("Different number of reference sequences in header and ref list... what happened?!")

--- a/src/Sam.jl
+++ b/src/Sam.jl
@@ -309,7 +309,9 @@ function read_bam_refs(io::IO)
 
     for i = 1:n_ref
         l_name = read(io, Int32)
-        name = rstrip(bytestring(read(io, Array(UInt8,l_name))),"\0")
+        # name is \0 terminated, we need to remove it
+        # for some reason, rstrip doesn't want to work.
+        name = replace(bytestring(read(io, Array(UInt8,l_name))), r"\0", "")
         l_ref = read(io, Int32)
         push!(refs, RefSeq(name, l_ref))
     end
@@ -331,7 +333,7 @@ function read_alignment(b::BamFile)
     blocksize = read(b.io, UInt32)
     info = unpack(b.io, AlignmentInfo, strpack_asize, align_packed, :LittleEndian)
 
-    readname = rstrip(bytestring(read(b.io, Array(UInt8, info.l_readname))), "\0")
+    readname = replace(bytestring(read(b.io, Array(UInt8, info.l_readname))), r"\0", "")
     cigar = read(b.io, Array(UInt32, info.n_cigar_op))
     seq = read(b.io, Array(UInt8, (info.rlen+1)>>1))
     qual = read(b.io, Array(UInt8, info.rlen))

--- a/src/Sam.jl
+++ b/src/Sam.jl
@@ -412,17 +412,16 @@ function samopen(io::GZipStream, mode="r"; meta=nothing)
         end
         if splitext(io.name)[2] == ".bam"
             bam = BamFile(io, meta)
-
         else
-            #Initialize writeable same
+            #TODO Initialize writeable same
         end
     else
         error("mode must be \"w\" or \"r\"")
     end
 end
 
-samopen(fn::AbstractString, mode="r"; header=nothing, refs=nothing) = samopen(GZip.open(fn, mode), mode, header=header, refs=refs)
-samopen(io::IOStream, mode="r"; header=nothing, refs=nothing) = samopen(GZip.gzdopen(fd(io)), mode, header=header, refs=refs)
+samopen(fn::AbstractString, mode="r"; meta=nothing) = samopen(GZip.open(fn, mode), mode, meta=meta)
+samopen(io::IOStream, mode="r"; meta=nothing) = samopen(GZip.gzdopen(fd(io)), mode, meta=meta)
 const open = samopen
 
 function samopen(f::Function, args...)


### PR DESCRIPTION
This pull request fixes some deprecation errors for Julia 0.4
As StrPack.jl hasn't tagged a new version since >1y I ran this against the pao/StrPack.jl@33b8afa, which works fine.

It still lacks a few things which I'd like to add in over the next week or two:
- [ ] Parse seq, cigar and qual from bam
- [ ] Include iterators for read()
- [ ] Perhaps change over to BioJulia/BufferedStreams.jl which might improve performance.
